### PR TITLE
cln: add cln as third peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Peerswap Playground
 
-This PeerSwap Playground provides a docker stack that comprises bitcoind, elementsd, 2x lnd nodes and 2x peerswap clients. It connects everything together, initializes the wallets, and creates a channel between the two nodes.
+This PeerSwap Playground provides a docker stack that comprises bitcoind, elementsd, 2x lnd nodes, 2x peerswap clients and 1 cln node with peerswap plugin. It connects everything together, initializes the wallets, and creates a channel between the nodes.
 
 You can use this to get familiar with [Peerswaps](https://www.peerswap.dev/).
 
 ## Usage
-
 **Start nodes:**
 
 ```sh
@@ -17,6 +16,13 @@ docker compose up
 ```sh
 ./scripts/init.sh
 ```
+
+**Clean everything:**
+```sh
+docker compose down --volumes
+```
+
+### LND Usage
 
 **Get the pubkey of one of the nodes:**
 
@@ -69,7 +75,58 @@ sleep 10
 ./bin/lncli lnd2 listchannels | grep -A 3 $CHANID
 ```
 
-**Clean everything:**
+### CLN Usage
+
+**Get the pubkey of one of the nodes:**
+
 ```sh
-docker compose down --volumes
+PUBKEY=$(./bin/lncli lnd2 getinfo  | jq -r '.identity_pubkey')
+```
+
+**Get details of channel connecting the nodes:**
+```sh
+CHANID=$(./bin/lncli lnd1 listchannels | jq -r --arg pubkey "$PUBKEY" '.channels[] | select(.remote_pubkey == $pubkey) | .chan_id')
+```
+
+```sh
+CLNSHORTCHANID=$(./bin/clncli listfunds | jq -r --arg pubkey "$PUBKEY" '.channels[] | select(.peer_id == $pubkey) | .short_channel_id')
+```
+
+**Initiate a swapout:**
+
+```sh
+bin/clncli peerswap-swap-out $CLNSHORTCHANID 1000000 lbtc
+```
+
+**Mine 3 blocks on the Liquid network:**
+
+```sh
+./bin/elements-cli -rpcwallet=cln1 -generate 3
+```
+
+**Wait ~10 seconds...**	
+
+```sh
+sleep 10
+```
+
+**Track progress:**
+
+```sh
+./bin/pscli peerswap2 listswaps
+./bin/clncli peerswap-listswaps
+```
+
+**Check liquid balances:**
+
+```sh
+./bin/pscli peerswap2 lbtc-getbalance
+./bin/clncli peerswap-lbtc-getbalance
+```
+
+**Check channel balance:**
+
+```sh
+./bin/lncli lnd2 listchannels | grep -A 3 $CHANID
+./bin/clncli listpeerchannels | grep -A 30 $CLNSHORTCHANID
 ```

--- a/bin/clncli
+++ b/bin/clncli
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+docker exec peerswap-playground-cln1-1 lightning-cli --regtest "${@:1}" || echo "Usage: clncli {clncli command, e.g. peerswap-listswaps}"

--- a/conf/peerswap/peerswap.conf
+++ b/conf/peerswap/peerswap.conf
@@ -1,0 +1,15 @@
+[Bitcoin]
+rpcuser="user"
+rpcpassword="pass"
+rpchost="http://bitcoind"
+rpcport=43782
+bitcoinswaps=true
+
+# Liquid section
+# Liquid rpc connection settings.
+[Liquid]
+rpcuser="user"
+rpcpassword="pass"
+rpchost="http://elementsd"
+rpcport=8332
+liquidswaps=true

--- a/conf/peerswap/policy.conf
+++ b/conf/peerswap/policy.conf
@@ -1,0 +1,2 @@
+reserve_onchain_msat=0
+accept_all_peers=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     image: lncm/bitcoind:v25.1
     restart: unless-stopped
     networks:
-        testing_net:
-            ipv4_address: 172.29.1.1
+      testing_net:
+        ipv4_address: 172.29.1.1
     volumes:
       - "bitcoind:/data/.bitcoin"
       - "./conf/bitcoind/bitcoin.conf:/data/.bitcoin/bitcoin.conf"
@@ -16,8 +16,8 @@ services:
     image: blockstream/elementsd:22.1.1
     restart: unless-stopped
     networks:
-        testing_net:
-            ipv4_address: 172.29.1.2
+      testing_net:
+        ipv4_address: 172.29.1.2
     command: elementsd
     volumes:
       - "elementsd:/root/.elements"
@@ -29,8 +29,8 @@ services:
     depends_on:
       - bitcoind
     networks:
-        testing_net:
-            ipv4_address: 172.29.1.3
+      testing_net:
+        ipv4_address: 172.29.1.3
     command: lnd --externalip=172.29.1.3 --externalip=lnd1:9735 --tlsextradomain=lnd1 --alias=lnd1
     volumes:
       - "lnd1:/root/.lnd"
@@ -43,8 +43,8 @@ services:
       - lnd1
       - elementsd
     networks:
-        testing_net:
-            ipv4_address: 172.29.1.4
+      testing_net:
+        ipv4_address: 172.29.1.4
     command: --lnd.host=lnd1:10009 --elementsd.rpcwallet=peerswap1 --host=localhost:42069
     volumes:
       - "lnd1:/root/.lnd"
@@ -58,8 +58,8 @@ services:
     depends_on:
       - bitcoind
     networks:
-        testing_net:
-            ipv4_address: 172.29.1.5
+      testing_net:
+        ipv4_address: 172.29.1.5
     command: lnd --externalip=172.29.1.5 --externalip=lnd2:9735 --tlsextradomain=lnd2 --alias=lnd2
     volumes:
       - "lnd2:/root/.lnd"
@@ -72,26 +72,51 @@ services:
       - lnd2
       - elementsd
     networks:
-        testing_net:
-            ipv4_address: 172.29.1.6
+      testing_net:
+        ipv4_address: 172.29.1.6
     command: --lnd.host=lnd2:10009 --elementsd.rpcwallet=peerswap2 --host=0.0.0.0:42069
     volumes:
       - "lnd2:/root/.lnd"
       - "peerswap2:/root/.peerswap"
       - "./conf/peerswapd/policy.conf:/root/.peerswap/policy.conf"
       - "./conf/peerswapd/peerswap.conf:/root/.peerswap/peerswap.conf"
+  cln1:
+    build:
+      context: .
+      dockerfile: ./dockerfile
+    restart: unless-stopped
+    depends_on:
+      - bitcoind
+      - elementsd
+    networks:
+      testing_net:
+        ipv4_address: 172.29.1.7
+    command:
+      - --bitcoin-rpcconnect=bitcoind
+      - --bitcoin-rpcport=43782
+      - --bitcoin-rpcuser=user
+      - --bitcoin-rpcpassword=pass
+      - --network=regtest
+      - --log-level=debug
+      - --plugin=/usr/local/libexec/c-lightning/plugins/peerswap
+    volumes:
+      - "cln1:/root/.peerswap"
+      - "./conf/peerswap/peerswap.conf:/root/.lightning/regtest/peerswap/peerswap.conf"
+      - "./conf/peerswap/policy.conf:/root/.lightning/regtest/peerswap/policy.conf"
 
 volumes:
-    bitcoind:
-    elementsd:
-    lnd1:
-    peerswap1:
-    lnd2:
-    peerswap2:
+  bitcoind:
+  elementsd:
+  lnd1:
+  peerswap1:
+  lnd2:
+  peerswap2:
+  cln1:
+
 
 networks:
-    testing_net:
-        ipam:
-            driver: default
-            config:
-                - subnet: 172.29.0.0/16
+  testing_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.29.0.0/16

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.21.4-bullseye as builder
+
+ARG PEERSWAP_VERSION=master
+
+# Force Go to use the cgo based DNS resolver. This is required to ensure DNS
+# queries required to connect to linked containers succeed.
+ENV GODEBUG netdns=cgo
+
+# Copy in the local repository to build from.
+RUN git clone --quiet --depth 1 --single-branch \
+    --branch $PEERSWAP_VERSION \
+    https://github.com/YusukeShimizu/peerswap /go/src/github.com/YusukeShimizu/peerswap
+
+RUN cd /go/src/github.com/YusukeShimizu/peerswap \
+    &&  make bins
+
+FROM elementsproject/lightningd:v23.11.2-arm64v8
+
+COPY --from=builder /go/src/github.com/YusukeShimizu/peerswap/out/peerswap /usr/local/libexec/c-lightning/plugins/
+RUN chmod +x /usr/local/libexec/c-lightning/plugins/peerswap
+RUN ls -la /
+
+ENTRYPOINT  [ "./entrypoint.sh" ]


### PR DESCRIPTION
Considering the case that we want to check the operation with cln, cln is added as the third peerswap peer.
The cln peer opens a channel to peerswap2.

I am building an image with docker file, but may need to move to docker hub.